### PR TITLE
Prevents redirect when viewing a reddit poll.

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,9 @@
 var host = "https://old.reddit.com/";
 chrome.webRequest.onBeforeRequest.addListener(
     function(details) {
-         return {redirectUrl: host + details.url.match(/^https?:\/\/[^\/]+([\S\s]*)/)[1]};
+        if(!details.url.match(/com\/poll/)){
+            return {redirectUrl: host + details.url.match(/^https?:\/\/[^\/]+([\S\s]*)/)[1]};
+        }
     },
     {
         urls: [


### PR DESCRIPTION
Reddit's poll functionality is limited to the new version of the site. Attempting to visit a reddit poll using `old.reddit.com` leads to a `404` response. I added a line to prevent redirect if someone is trying to view a poll.